### PR TITLE
Feat/common navigation link

### DIFF
--- a/src/components/common/NavigationLink.tsx
+++ b/src/components/common/NavigationLink.tsx
@@ -1,13 +1,6 @@
 import { Link, useLocation } from 'react-router-dom';
-import type { ReactNode } from 'react';
 import { designTokens } from '../../design-tokens';
-
-type NavigationLinkProps = {
-    to: string;
-    label: string;
-    icon: ReactNode;
-    className?: string;
-};
+import type { NavigationLink as NavigationLinkProps } from '../types'
 
 export const NavigationLink = ({ to, label, icon, className }: NavigationLinkProps) => {
     const location = useLocation();

--- a/src/components/layout/MainNavigation.tsx
+++ b/src/components/layout/MainNavigation.tsx
@@ -1,0 +1,71 @@
+import { designTokens } from '../../design-tokens';
+import { NavigationLink } from '../common/NavigationLink';
+import type { NavItem, MainNavigation as MainNavigationProps } from '../types';
+
+export const MainNavigation = ({
+    logo,
+    itemsPrimary,
+    itemsSecondary,
+    className,
+    ariaLable = 'Main Navigation'
+}: MainNavigationProps) => {
+    ///navigation group wrapper style
+    const navStyle = {
+        display: 'flex',
+        flexDirection: 'column' as const,
+        boxSizing: 'border-box' as const,
+        width: 314,
+        height: '100%',
+        gap: designTokens.spacing.m,
+        padding: `${designTokens.spacing.l} ${designTokens.spacing.s}`,
+        backgroundColor: designTokens.colors.fill.tertiary,
+    }
+    // logo wrapper style
+    const logoStyle = {
+        display: 'flex',
+        alignItems: 'center',
+        padding: `0 0 0 ${designTokens.spacing.s}`,
+    }
+    // navigation link wrapper style
+    const listStyle = {
+        padding: 0,
+        display: 'flex',
+        flexDirection: 'column' as const,
+        listStyle: 'none' as const,
+        gap: designTokens.spacing.xxxs,
+    }
+
+    // render a group of navigation links
+    const renderNavGroup = (items: NavItem[], primary = false) => {
+        return (
+            <ul
+                style={{
+                    ...listStyle,
+                    margin: primary ? '0' : 'auto 0 0'
+                }}
+            >
+                {items.map((item) => (
+                    <li key={item.to}>
+                        <NavigationLink
+                            to={item.to}
+                            label={item.label}
+                            icon={item.icon}
+                        />
+                    </li>
+                ))}
+            </ul>
+        );
+    }
+
+    return (
+        <nav
+            className={className}
+            style={navStyle}
+            aria-label={ariaLable}
+        >
+            <div style={logoStyle}>{logo}</div>
+            {renderNavGroup(itemsPrimary, true)}
+            {itemsSecondary && itemsSecondary.length > 0 && renderNavGroup(itemsSecondary)}
+        </nav>
+    );
+}

--- a/src/components/layout/types.ts
+++ b/src/components/layout/types.ts
@@ -1,0 +1,8 @@
+export type NavItem = {
+    to: string;
+    label: string;
+    icon?: React.ReactNode;
+    disabled?: boolean; // for the feature that are not avaialbe yet
+    external?: boolean; // wheter the link is external link
+    target?: "_blank" | "_self"; // for external link targert, opens in new tab or same tab
+};

--- a/src/components/layout/types.ts
+++ b/src/components/layout/types.ts
@@ -1,8 +1,0 @@
-export type NavItem = {
-    to: string;
-    label: string;
-    icon?: React.ReactNode;
-    disabled?: boolean; // for the feature that are not avaialbe yet
-    external?: boolean; // wheter the link is external link
-    target?: "_blank" | "_self"; // for external link targert, opens in new tab or same tab
-};

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+export type NavItem = {
+    to: string;
+    label: string;
+    icon?: React.ReactNode;
+    disabled?: boolean; // for the feature that are not avaialbe yet
+    external?: boolean; // wheter the link is external link
+    target?: "_blank" | "_self"; // for external link targert, opens in new tab or same tab
+};
+
+export type MainNavigation = {
+    logo: ReactNode;
+    itemsPrimary: NavItem[];
+    itemsSecondary?: NavItem[];
+    className?: string;
+    ariaLable?: string;
+}
+
+export type NavigationLink = {
+    to: string;
+    label: string;
+    icon: ReactNode;
+    className?: string;
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,12 @@
-import { Routes, Route, Link } from "react-router-dom";
+import { Routes, Route } from "react-router-dom";
+import { MainNavigation } from "./components/layout/MainNavigation";
+import {
+  Home as HomeIcon,
+  Phone, BookUser,
+  Settings as SettingsIcon,
+  CircleUserRound
+} from "lucide-react";
+import { designTokens } from "./design-tokens";
 import Home from "./pages/Home";
 import Contacts from "./pages/Contacts";
 import Calls from "./pages/Calls";
@@ -7,20 +15,48 @@ import NotFound from "./pages/NotFound";
 
 export default function AppRoutes() {
   return (
-    <>
-      <nav>
-        <Link to="/">Home</Link>
-        <Link to="/contacts">Customers</Link>
-        <Link to="/calls">Call History</Link>
-        <Link to="/settings">Settings</Link>
-      </nav>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/contacts" element={<Contacts />} />
-        <Route path="/calls" element={<Calls />} />
-        <Route path="/settings" element={<Settings />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
-    </>
+    <div style={{ display: 'flex', flexDirection: 'row', height: '100vh' }}>
+      <MainNavigation
+        logo={<span>Logo</span>}
+        itemsPrimary={[
+          {
+            to: "/",
+            label: "Home",
+            icon: <HomeIcon size={20} strokeWidth={1.5} color={designTokens.colors.glyph.default} />
+          },
+          {
+            to: "/calls",
+            label: "Call History",
+            icon: <Phone size={20} strokeWidth={1.5} color={designTokens.colors.glyph.default} />
+          }
+          ,
+          {
+            to: "/contacts",
+            label: "Customers",
+            icon: <BookUser size={20} strokeWidth={1.5} color={designTokens.colors.glyph.default} />
+          },
+        ]}
+        itemsSecondary={[
+          {
+            to: "/settings",
+            label: "Settings",
+            icon: <SettingsIcon size={20} strokeWidth={1.5} color={designTokens.colors.glyph.default} />
+          },
+          {
+            to: "/profile",
+            label: "User Name",
+            icon: <CircleUserRound size={20} strokeWidth={1.5} color={designTokens.colors.glyph.default} />
+          }
+        ]} />
+      <div style={{ flex: 1, overflow: 'auto' }}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/contacts" element={<Contacts />} />
+          <Route path="/calls" element={<Calls />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Add MainNavigation layout components and refactor the types
This pull request is mainly about adding a new layout components named `MainNavigation.tsx` and refactoring the relevant types structure along the way. 

## Key changes
- Added `MainNavigation` layout component for side bar navigation structure and styling.
- Defined `NavItem`, `MainNavigation`, and `NavigationLink` types/interfaces in a new file for maintainability and type safety.
- Updated `routes.tsx` to use the new `MainNavigation` components, rendering distinct primary and secondary navigation groups.

## Motivation
By centralizing navigation logic and types, future changes such as adding sidebar features, external links, or disabling items become easier. 

## Demoable deliverables
- Sidebar navigation with grouped items and icons.
- Type-safe navigation configuration for easier extension.
- Clean separation of layout, component, and type logic