### PR TITLE
Feat/common list item

### DIFF
--- a/src/components/calls/CallItem.tsx
+++ b/src/components/calls/CallItem.tsx
@@ -8,7 +8,7 @@ const callTypeIconMap = {
     missed: <PhoneMissed size={16} strokeWidth={1.5} color={designTokens.colors.glyph.default} />
 };
 
-export function CallsItem({
+export function CallItem({
     callType,
     contactName,
     callTime,

--- a/src/components/calls/CallItem.tsx
+++ b/src/components/calls/CallItem.tsx
@@ -1,6 +1,7 @@
 import { designTokens } from '../../design-tokens';
 import { PhoneOutgoing, PhoneIncoming, PhoneMissed } from 'lucide-react';
 import { ListItem } from '../common/ListItem';
+import type { CallItem as CallItemProps } from '../types'
 
 const callTypeIconMap = {
     outgoing: <PhoneOutgoing size={16} strokeWidth={1.5} color={designTokens.colors.glyph.default} />,
@@ -9,23 +10,17 @@ const callTypeIconMap = {
 };
 
 export function CallItem({
+    callId,
+    phoneNumber,
     callType,
-    contact,
+    contactName,
     callTime,
     duration,
     selected,
     onClick
-}: {
-    callType: 'outgoing' | 'incoming' | 'missed';
-    contact: {
-        name?: string;
-        phoneNumber: string
-    };
-    callTime: string;
-    duration?: string;
-    selected?: boolean;
-    onClick?: () => void;
-}) {
+}: CallItemProps) {
+
+    const isSelected = (typeof selected === 'string' ? callId === selected : selected === true);
     const durationNum = Number(duration);
     const hours = Math.floor(durationNum / 3600);
     const minutes = Math.round((durationNum % 3600) / 60);
@@ -37,15 +32,30 @@ export function CallItem({
             ].filter(Boolean).join(' ')
             : undefined;
 
+    // Format date as DD.MM.YYYY HH:MM AM/PM
+    const dateObj = new Date(callTime);
+    const day = String(dateObj.getDate()).padStart(2, '0');
+    const month = String(dateObj.getMonth() + 1).padStart(2, '0');
+    const year = dateObj.getFullYear();
+    let hours12 = dateObj.getHours();
+    const minutesStr = String(dateObj.getMinutes()).padStart(2, '0');
+    const ampm = hours12 >= 12 ? 'PM' : 'AM';
+    hours12 = hours12 % 12;
+    hours12 = hours12 ? hours12 : 12;
+    const formattedTime = `${day}.${month}.${year} · ${hours12}:${minutesStr}${ampm}`;
+    const subText = formattedTime;
+
+    const text = contactName?.name ?? phoneNumber;
+
     return (
         <ListItem
             icon={callTypeIconMap[callType]}
-            text={contact?.name ?? contact?.phoneNumber}
-            subText={new Date(callTime).toLocaleString()}
+            text={text}
+            subText={subText}
+            selected={isSelected}
             infoText={infoText}
-            selected={selected}
             onClick={onClick}
-            ariaLabel={`Call with ${contact?.name ?? contact?.phoneNumber} at ${new Date(callTime).toLocaleString()} ${duration ? ` for ${infoText}` : ''}`}
+            ariaLabel={`Call with ${text} at ${formattedTime}${duration ? ` for ${infoText}` : ''}`}
         />
     );
 }

--- a/src/components/calls/CallItem.tsx
+++ b/src/components/calls/CallItem.tsx
@@ -10,22 +10,22 @@ const callTypeIconMap = {
 
 export function CallItem({
     callType,
-    contactName,
+    contact,
     callTime,
     duration,
     selected,
     onClick
 }: {
     callType: 'outgoing' | 'incoming' | 'missed';
-    contactName: { name?: string; phoneNumber: string };
+    contact: {
+        name?: string;
+        phoneNumber: string
+    };
     callTime: string;
     duration?: string;
     selected?: boolean;
     onClick?: () => void;
 }) {
-    const text = contactName?.name ?? contactName?.phoneNumber;
-    const subText = new Date(callTime).toLocaleString();
-
     const durationNum = Number(duration);
     const hours = Math.floor(durationNum / 3600);
     const minutes = Math.round((durationNum % 3600) / 60);
@@ -40,12 +40,12 @@ export function CallItem({
     return (
         <ListItem
             icon={callTypeIconMap[callType]}
-            text={text}
-            subText={subText}
+            text={contact?.name ?? contact?.phoneNumber}
+            subText={new Date(callTime).toLocaleString()}
             infoText={infoText}
             selected={selected}
             onClick={onClick}
-            ariaLabel={`Call with ${text} at ${subText} during ${duration ? `, duration ${infoText}` : ''}`}
+            ariaLabel={`Call with ${contact?.name ?? contact?.phoneNumber} at ${new Date(callTime).toLocaleString()} ${duration ? ` for ${infoText}` : ''}`}
         />
     );
 }

--- a/src/components/calls/CallList.tsx
+++ b/src/components/calls/CallList.tsx
@@ -1,0 +1,48 @@
+import { designTokens } from "../../design-tokens";
+import { CallItem } from "./CallItem";
+import type { CallList as ContactListProps, ContactItem } from "../types";
+
+export function CallList({
+    calls,
+    selectedCallId,
+    onCallSelect,
+    className,
+    ariaLabel,
+}: ContactListProps & { contact?: ContactItem['contact'] }) {
+
+    const listStyle: React.CSSProperties = {
+        listStyle: "none",
+        margin: 0,
+        padding: `0 ${designTokens.spacing.xxs}`,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: designTokens.spacing.xxxs,
+        flex: '1 0 0'
+    };
+
+    return (
+        <ul
+            role="list"
+            style={listStyle}
+            className={className}
+            aria-label={ariaLabel || 'Call List'}
+            tabIndex={0}
+        >
+            {calls.map(call => {
+
+                return (
+                    <CallItem
+                        callId={call.callId}
+                        callType={call.callType}
+                        callTime={call.callTime}
+                        phoneNumber={call.phoneNumber}
+                        contactName={call.contactName}
+                        duration={call.duration}
+                        selected={call.callId === selectedCallId}
+                        onClick={() => onCallSelect?.(call.callId)}
+                    />
+                );
+            })}
+        </ul>
+    );
+}

--- a/src/components/calls/CallList.tsx
+++ b/src/components/calls/CallList.tsx
@@ -1,6 +1,7 @@
 import { designTokens } from "../../design-tokens";
 import { CallItem } from "./CallItem";
 import type { CallList as ContactListProps, ContactItem } from "../types";
+import { useCallback } from "react";
 
 export function CallList({
     calls,
@@ -17,8 +18,26 @@ export function CallList({
         display: 'flex',
         flexDirection: 'column',
         gap: designTokens.spacing.xxxs,
-        flex: '1 0 0'
+        flex: '1 0 0',
     };
+
+    const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLUListElement>) => {
+        if (!calls.length || !onCallSelect) return;
+
+        const index = selectedCallId
+            ? calls.findIndex(call => call.callId === selectedCallId)
+            : -1;
+
+        if (event.key === 'ArrowDown') {
+            const nextIndex = index < calls.length - 1 ? index + 1 : 0;
+            onCallSelect(calls[nextIndex].callId);
+            event.preventDefault();
+        } else if (event.key === 'ArrowUp') {
+            const prevIndex = index > 0 ? index - 1 : calls.length - 1;
+            onCallSelect(calls[prevIndex].callId);
+            event.preventDefault();
+        }
+    }, [calls, selectedCallId, onCallSelect]);
 
     return (
         <ul
@@ -27,6 +46,7 @@ export function CallList({
             className={className}
             aria-label={ariaLabel || 'Call List'}
             tabIndex={0}
+            onKeyDown={handleKeyDown}
         >
             {calls.map(call => {
 

--- a/src/components/calls/callsItem.tsx
+++ b/src/components/calls/callsItem.tsx
@@ -1,0 +1,51 @@
+import { designTokens } from '../../design-tokens';
+import { PhoneOutgoing, PhoneIncoming, PhoneMissed } from 'lucide-react';
+import { ListItem } from '../common/ListItem';
+
+const callTypeIconMap = {
+    outgoing: <PhoneOutgoing size={16} strokeWidth={1.5} color={designTokens.colors.glyph.default} />,
+    incoming: <PhoneIncoming size={16} strokeWidth={1.5} color={designTokens.colors.glyph.default} />,
+    missed: <PhoneMissed size={16} strokeWidth={1.5} color={designTokens.colors.glyph.default} />
+};
+
+export function CallsItem({
+    callType,
+    contactName,
+    callTime,
+    duration,
+    selected,
+    onClick
+}: {
+    callType: 'outgoing' | 'incoming' | 'missed';
+    contactName: { name?: string; phoneNumber: string };
+    callTime: string;
+    duration?: string;
+    selected?: boolean;
+    onClick?: () => void;
+}) {
+    const text = contactName?.name ?? contactName?.phoneNumber;
+    const subText = new Date(callTime).toLocaleString();
+
+    const durationNum = Number(duration);
+    const hours = Math.floor(durationNum / 3600);
+    const minutes = Math.round((durationNum % 3600) / 60);
+    const infoText =
+        duration != null
+            ? [
+                hours >= 1 ? `${hours} hours` : null,
+                `${minutes} minutes`
+            ].filter(Boolean).join(' ')
+            : undefined;
+
+    return (
+        <ListItem
+            icon={callTypeIconMap[callType]}
+            text={text}
+            subText={subText}
+            infoText={infoText}
+            selected={selected}
+            onClick={onClick}
+            ariaLabel={`Call with ${text} at ${subText} during ${duration ? `, duration ${infoText}` : ''}`}
+        />
+    );
+}

--- a/src/components/common/ListItem.tsx
+++ b/src/components/common/ListItem.tsx
@@ -1,0 +1,118 @@
+import type React from 'react';
+import type { ListItem as ListItemProps } from '../types';
+import { designTokens } from '../../design-tokens';
+
+export const ListItem = ({
+    icon,
+    imageSrc,
+    text,
+    subText,
+    infoText,
+    selected = false,
+    onClick,
+    ariaLabel,
+    className
+}: ListItemProps) => {
+
+    const wrapperStyle: React.CSSProperties = {
+        display: 'flex',
+        alignItems: 'center',
+        gap: designTokens.spacing.xs,
+        padding: designTokens.spacing.s,
+        borderRadius: designTokens.border.radius.roundMd,
+        cursor: onClick ? 'pointer' : 'default',
+        background: selected ? designTokens.colors.fill.tertiary : undefined,
+    };
+
+    const mediaStyle: React.CSSProperties = {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: 32,
+        height: 32,
+        overflow: 'hidden'
+    };
+
+    const textWrapperStyle: React.CSSProperties = {
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        minWidth: 0, // to enable text truncation
+    };
+
+    const textStyle: React.CSSProperties = {
+        ...designTokens.typography.body,
+        color: designTokens.colors.glyph.default,
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+    };
+
+    const subTextStyle: React.CSSProperties = {
+        ...designTokens.typography.bodySmall,
+        color: designTokens.colors.glyph.muted,
+    };
+
+    const infoTextStyle: React.CSSProperties = {
+        ...designTokens.typography.micro,
+        color: designTokens.colors.glyph.muted,
+        flexShrink: 0,
+    };
+
+    // keyboard activation for accessibility
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (onClick && (e.key === "Enter" || e.key === " ")) {
+            e.preventDefault();
+            onClick();
+        }
+    };
+
+    // focus outlined style
+    const applyFocusOutlined = (el: HTMLDivElement) => {
+        el.style.boxShadow = `0 0 0 ${designTokens.border.width[1]} ${designTokens.colors.border.focus}`;
+    };
+    const removeFocusOutlined = (el: HTMLDivElement) => {
+        el.style.boxShadow = "none";
+    };
+
+    return (
+        <div
+            onClick={onClick}
+            style={wrapperStyle}
+            className={className}
+
+            // accessibility
+            role={onClick ? 'button' : 'listitem'}
+            tabIndex={onClick ? 0 : -1}
+            aria-label={ariaLabel ?? text}
+            aria-current={selected ? 'true' : undefined}
+
+            // keyboard and focus handling
+            onKeyDown={handleKeyDown}
+            onFocus={(e) => applyFocusOutlined(e.currentTarget)}
+            onBlur={(e) => removeFocusOutlined(e.currentTarget)}
+            onMouseEnter={(e) => {
+                if (!selected) {
+                    e.currentTarget.style.backgroundColor = designTokens.colors.fill.tertiary;
+                }
+            }}
+            onMouseLeave={(e) => {
+                if (!selected) {
+                    e.currentTarget.style.backgroundColor = 'transparent';
+                }
+            }}
+        >
+            {(icon || imageSrc) && (
+                <div style={mediaStyle}>
+                    {icon && <span>{icon}</span>}
+                    {imageSrc && <img src={imageSrc} alt="" style={{ width: '100%', height: '100%', objectFit: 'cover' }} />}
+                </div>
+            )}
+            <div style={textWrapperStyle}>
+                <span style={textStyle}>{text}</span>
+                {subText && <span style={subTextStyle}>{subText}</span>}
+            </div>
+            {infoText && <span style={infoTextStyle}>{infoText}</span>}
+        </div>
+    )
+}

--- a/src/components/common/ListItem.tsx
+++ b/src/components/common/ListItem.tsx
@@ -8,10 +8,10 @@ export const ListItem = ({
     text,
     subText,
     infoText,
-    selected = false,
-    onClick,
+    selected,
     ariaLabel,
-    className
+    className,
+    onClick
 }: ListItemProps) => {
 
     const wrapperStyle: React.CSSProperties = {
@@ -20,8 +20,9 @@ export const ListItem = ({
         gap: designTokens.spacing.xs,
         padding: designTokens.spacing.s,
         borderRadius: designTokens.border.radius.roundMd,
-        cursor: onClick ? 'pointer' : 'default',
-        background: selected ? designTokens.colors.fill.tertiary : undefined,
+        cursor: 'pointer',
+        userSelect: 'none',
+
     };
 
     const mediaStyle: React.CSSProperties = {
@@ -59,26 +60,13 @@ export const ListItem = ({
         flexShrink: 0,
     };
 
-    // keyboard activation for accessibility
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-        if (onClick && (e.key === "Enter" || e.key === " ")) {
-            e.preventDefault();
-            onClick();
-        }
-    };
-
-    // focus outlined style
-    const applyFocusOutlined = (el: HTMLDivElement) => {
-        el.style.boxShadow = `0 0 0 ${designTokens.border.width[1]} ${designTokens.colors.border.focus}`;
-    };
-    const removeFocusOutlined = (el: HTMLDivElement) => {
-        el.style.boxShadow = "none";
-    };
-
     return (
         <div
             onClick={onClick}
-            style={wrapperStyle}
+            style={{
+                ...wrapperStyle,
+                background: selected ? designTokens.colors.fill.tertiary : undefined
+            }}
             className={className}
 
             // accessibility
@@ -86,21 +74,6 @@ export const ListItem = ({
             tabIndex={onClick ? 0 : -1}
             aria-label={ariaLabel ?? text}
             aria-current={selected ? 'true' : undefined}
-
-            // keyboard and focus handling
-            onKeyDown={handleKeyDown}
-            onFocus={(e) => applyFocusOutlined(e.currentTarget)}
-            onBlur={(e) => removeFocusOutlined(e.currentTarget)}
-            onMouseEnter={(e) => {
-                if (!selected) {
-                    e.currentTarget.style.backgroundColor = designTokens.colors.fill.tertiary;
-                }
-            }}
-            onMouseLeave={(e) => {
-                if (!selected) {
-                    e.currentTarget.style.backgroundColor = 'transparent';
-                }
-            }}
         >
             {(icon || imageSrc) && (
                 <div style={mediaStyle}>

--- a/src/components/common/ListItem.tsx
+++ b/src/components/common/ListItem.tsx
@@ -22,7 +22,7 @@ export const ListItem = ({
         borderRadius: designTokens.border.radius.roundMd,
         cursor: 'pointer',
         userSelect: 'none',
-
+        outline: 'none'
     };
 
     const mediaStyle: React.CSSProperties = {

--- a/src/components/contacts/ContactItem.tsx
+++ b/src/components/contacts/ContactItem.tsx
@@ -1,21 +1,11 @@
 import { ListItem } from "../common/ListItem";
+import type { ContactItem as ContactItemProps } from "../types";
 
 export function ContactItem({
     contact,
     selected,
     onClick
-}: {
-    contact: {
-        name: string,
-        phoneNumber: string,
-        id: string,
-        avatarUrl?: string,
-        totalCallCount?: number
-    };
-    selected?: boolean;
-    onClick?: () => void;
-}) {
-
+}: ContactItemProps) {
     return (
         <ListItem
             text={contact.name}

--- a/src/components/contacts/ContactItem.tsx
+++ b/src/components/contacts/ContactItem.tsx
@@ -1,0 +1,30 @@
+import { ListItem } from "../common/ListItem";
+
+export function ContactItem({
+    contact,
+    selected,
+    onClick
+}: {
+    contact: {
+        name: string,
+        phoneNumber: string,
+        id: string,
+        avatarUrl?: string,
+        totalCallCount?: number
+    };
+    selected?: boolean;
+    onClick?: () => void;
+}) {
+
+    return (
+        <ListItem
+            text={contact.name}
+            subText={contact.phoneNumber}
+            infoText={contact.totalCallCount != null ? `${contact.totalCallCount} calls` : undefined}
+            imageSrc={contact.avatarUrl}
+            selected={selected}
+            onClick={onClick}
+            ariaLabel={`Contact ${contact.name}`}
+        />
+    );
+}

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,3 +1,4 @@
+import type React from "react";
 import type { ReactNode } from "react";
 
 export type NavItem = {
@@ -21,5 +22,17 @@ export type NavigationLink = {
     to: string;
     label: string;
     icon: ReactNode;
+    className?: string;
+}
+
+export type ListItem = {
+    icon?: React.ReactNode;
+    imageSrc?: string;
+    text: string;
+    subText?: string;
+    infoText?: string;
+    selected?: boolean;
+    onClick?: () => void;
+    ariaLabel?: string;
     className?: string;
 }

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -36,3 +36,34 @@ export type ListItem = {
     ariaLabel?: string;
     className?: string;
 }
+
+export type CallItem = {
+    callId: string;
+    callType: 'outgoing' | 'incoming' | 'missed';
+    callTime: string;
+    phoneNumber: string;
+    contactName?: ContactItem['contact'];
+    duration?: string;
+    selected?: boolean;
+    onClick?: () => void;
+};
+
+export type ContactItem = {
+    contact: {
+        name: string,
+        phoneNumber: string,
+        id: string,
+        avatarUrl?: string,
+        totalCallCount?: number
+    };
+    selected?: boolean;
+    onClick?: () => void;
+};
+
+export type CallList = {
+    calls: CallItem[];
+    selectedCallId?: string;
+    onCallSelect?: (callId: string) => void;
+    className?: string;
+    ariaLabel?: string;
+}

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -1,0 +1,12 @@
+export const mockContacts = [
+    { id: "c1", name: "Alice Müller", phoneNumber: "+49 151 2345678", avatarUrl: "", totalCallCount: 12 },
+    { id: "c2", name: "Bob Schneider", phoneNumber: "+49 171 9876543", avatarUrl: "", totalCallCount: 3 },
+    { id: "c3", name: "Jisu Kim", phoneNumber: "+49 160 5550001", avatarUrl: "", totalCallCount: 2 },
+];
+
+export const mockCalls = [
+    { id: "k1", contactId: "c1", phoneNumber: "+49 151 2345678", direction: "incoming" as const, startedAt: "2025-09-23T08:15:00Z", duration: 225 },
+    { id: "k2", contactId: "c2", phoneNumber: "+49 171 9876543", direction: "outgoing" as const, startedAt: "2025-09-22T13:45:00Z", duration: 78 },
+    { id: "k3", contactId: "c3", phoneNumber: "+49 160 5550001", direction: "missed" as const, startedAt: "2025-09-24T06:05:00Z", duration: 234 },
+    { id: "k4", contactId: "unknown", phoneNumber: "+49 160 5550001", direction: "missed" as const, startedAt: "2025-09-24T06:05:00Z", duration: 234 },
+];

--- a/src/pages/Calls.tsx
+++ b/src/pages/Calls.tsx
@@ -1,3 +1,57 @@
+import { mockCalls, mockContacts } from '../mocks/data';
+import { CallList } from '../components/calls/CallList';
+import { useState } from 'react';
+import { designTokens } from '../design-tokens';
+
+
 export default function Calls() {
-  return <div>Calls</div>;
+  const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
+
+  if (!mockCalls.length) {
+    return <div>No calls found</div>;
+  }
+
+  const callsWithContact = mockCalls.map(call => {
+    const contact = mockContacts.find(c => c.id === call.contactId);
+    return {
+      ...call,
+      callType: call.direction,
+      callTime: call.startedAt,
+      duration: call.duration != null ? `${call.duration}` : undefined,
+      contactName: contact ? contact : undefined,
+      phoneNumber: call.phoneNumber,
+      callId: call.id
+    };
+  });
+
+  const selectedCall = callsWithContact.find(call => call.callId === selectedId);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'row', height: '100%' }}>
+      <CallList
+        calls={callsWithContact}
+        selectedCallId={selectedId}
+        onCallSelect={setSelectedId}
+        className=""
+        ariaLabel="Call History"
+      />
+      <div style={{
+        maxWidth: 400,
+        margin: '0 auto',
+        display: 'flex',
+        flexDirection: 'column',
+        flex: `1 0 0`,
+        padding: `0 ${designTokens.spacing.l}`,
+        borderLeft: `${designTokens.border.width[1]} solid ${designTokens.colors.border.muted}`,
+      }}>
+        <strong style={designTokens.typography.title3}>Selected Call Debug</strong>
+        <pre style={{
+          ...designTokens.typography.micro,
+          whiteSpace: 'pre-wrap',
+        }}>
+          {selectedCall ? JSON.stringify(selectedCall, null, 2) : 'No call selected'}
+        </pre>
+      </div>
+    </div>
+  );
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
-import contactReducer from './contactsSlice.ts';
+import contactReducer from './contactsSlice';
 
 export const store = configureStore({
     reducer: {


### PR DESCRIPTION
### PR: Add Common ListItem Component and Feature-Specific CallList & CallItem

## Summary
This PR introduces a reusable ‎`ListItem` component, designed as a visual-only list row for use in both ‎`Contacts` and ‎`Calls`. Additionally, it adds domain-specific wrapper components: ‎`CallItem` and ‎`CallList`, which leverage the common ‎`ListItem` for rendering call history. Temporary mock data and layout adjustments are included for debugging and testing purposes.

## Details
- Added ‎`ListItem`: a generic component for consistent list row UI
- Added ‎`CallItem`: a feature-specific wrapper for rendering individual call history, mapping call data to the common ‎`ListItem`.
- Added ‎`CallList`: a feature-specific wrapper for rendering a list of calls, including keyboard navigation (ArrowUp/ArrowDown) for accessibility.
- Added shared types for ‎‎`ListItem`, ‎‎`CallItem`, ‎‎`ContactItem`, and ‎‎`CallList` in ‎‎`src/components/types.ts` to standardize props and improve type safety.
- Added temporary mock data and debug layout in ‎`Calls` page for manual testing.