### PR TITLE
Feat/create title wrapper

### DIFF
--- a/src/components/calls/CallItem.tsx
+++ b/src/components/calls/CallItem.tsx
@@ -4,9 +4,9 @@ import { ListItem } from '../common/ListItem';
 import type { CallItem as CallItemProps } from '../types'
 
 const callTypeIconMap = {
-    outgoing: <PhoneOutgoing size={16} strokeWidth={1.5} color={designTokens.colors.glyph.default} />,
-    incoming: <PhoneIncoming size={16} strokeWidth={1.5} color={designTokens.colors.glyph.default} />,
-    missed: <PhoneMissed size={16} strokeWidth={1.5} color={designTokens.colors.glyph.default} />
+    outgoing: <PhoneOutgoing size={20} strokeWidth={1.5} color={designTokens.colors.glyph.default} />,
+    incoming: <PhoneIncoming size={20} strokeWidth={1.5} color={designTokens.colors.glyph.default} />,
+    missed: <PhoneMissed size={20} strokeWidth={1.5} color={designTokens.colors.glyph.default} />
 };
 
 export function CallItem({

--- a/src/components/common/Divider.tsx
+++ b/src/components/common/Divider.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import type { Divider as DividerProps } from '../types';
+import { designTokens } from "../../design-tokens";
+
+export const Divider = ({
+    direction,
+    color,
+    width,
+    spacing
+}: DividerProps) => {
+
+    const directionMap: { [key in DividerProps['direction']]: React.CSSProperties } = {
+        horizontal: {
+            display: 'flex',
+            flexDirection: 'column',
+            flex: '0 1 0',
+            height: 1
+        },
+        vertical: {
+            display: 'flex',
+            flex: '1 0 0',
+            width: 1
+        }
+    }
+
+    const spacingMap = {
+        l: designTokens.spacing.s,
+        m: designTokens.spacing.m,
+        s: designTokens.spacing.s,
+        xs: designTokens.spacing.xs,
+        xxs: designTokens.spacing.xxs
+    }
+
+    return (
+        <div
+            style={{
+                ...directionMap[direction || 'horizontal'],
+                backgroundColor: color || designTokens.colors.border.default,
+                width: (direction === 'horizontal' ? '100%' : `${width}`) || `${designTokens.border.width[1]}`,
+                height: (direction === 'horizontal' ? `${width}` : '100%') || `${designTokens.border.width[1]}`,
+                margin: direction === 'horizontal'
+                    ? `${spacingMap[spacing || 'm']} 0`
+                    : `0 ${spacingMap[spacing || 'm']}`
+            }}>
+
+        </div>
+    )
+}

--- a/src/components/common/TitleWrapper.tsx
+++ b/src/components/common/TitleWrapper.tsx
@@ -1,0 +1,43 @@
+import type React from 'react';
+import type { TitleWrapper as TitleWrapperProps } from "../types";
+import { designTokens } from "../../design-tokens";
+import { Divider } from './Divider';
+
+
+export const TitleWrapper = ({
+    title,
+    titleSize,
+    divider,
+    className
+}: TitleWrapperProps) => {
+
+    const containerStyle: React.CSSProperties = {
+        display: 'flex',
+        flexDirection: 'column',
+        padding: ` ${designTokens.spacing.l} ${designTokens.spacing.l} 0`,
+    };
+
+    const titleSizeMap = {
+        l: designTokens.typography.title1,
+        m: designTokens.typography.title2,
+        s: designTokens.typography.title3,
+    };
+
+    return (
+        <div
+            style={containerStyle}
+        >
+            <span
+                className={className}
+                style={titleSizeMap[titleSize]}>
+                {title}
+            </span>
+            {divider && <Divider
+                direction="horizontal"
+                spacing="m"
+                color={designTokens.colors.border.default}
+                width={designTokens.border.width[1]}
+            />}
+        </div>
+    )
+}

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -67,3 +67,17 @@ export type CallList = {
     className?: string;
     ariaLabel?: string;
 }
+
+export type TitleWrapper = {
+    title: string;
+    titleSize: `l` | `m` | `s`;
+    divider?: boolean;
+    className?: string;
+};
+
+export type Divider = {
+    direction: `horizontal` | `vertical`;
+    spacing: `l` | `m` | `s` | `xs` | `xxs`;
+    color: string;
+    width: string;
+}

--- a/src/pages/Calls.tsx
+++ b/src/pages/Calls.tsx
@@ -2,6 +2,7 @@ import { mockCalls, mockContacts } from '../mocks/data';
 import { CallList } from '../components/calls/CallList';
 import { useState } from 'react';
 import { designTokens } from '../design-tokens';
+import { TitleWrapper } from '../components/common/TitleWrapper';
 
 
 export default function Calls() {
@@ -26,15 +27,37 @@ export default function Calls() {
 
   const selectedCall = callsWithContact.find(call => call.callId === selectedId);
 
+  const pageStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'row',
+    height: '100%'
+  };
+
+  const listPaneStyle: React.CSSProperties = {
+    display: 'flex',
+    width: 420,
+    flexDirection: 'column',
+    alignSelf: 'stretch',
+    borderRight: `${designTokens.border.width[1]} solid ${designTokens.colors.border.muted}`,
+    flex: '0 0 auto',
+  };
+
   return (
-    <div style={{ display: 'flex', flexDirection: 'row', height: '100%' }}>
-      <CallList
-        calls={callsWithContact}
-        selectedCallId={selectedId}
-        onCallSelect={setSelectedId}
-        className=""
-        ariaLabel="Call History"
-      />
+    <div style={pageStyle}>
+      <div style={listPaneStyle}>
+        <TitleWrapper
+          title="Recents"
+          titleSize="s"
+          divider={false}
+        />
+        <CallList
+          calls={callsWithContact}
+          selectedCallId={selectedId}
+          onCallSelect={setSelectedId}
+          className=""
+          ariaLabel="Call History"
+        />
+      </div>
       <div style={{
         maxWidth: 400,
         margin: '0 auto',
@@ -42,7 +65,6 @@ export default function Calls() {
         flexDirection: 'column',
         flex: `1 0 0`,
         padding: `0 ${designTokens.spacing.l}`,
-        borderLeft: `${designTokens.border.width[1]} solid ${designTokens.colors.border.muted}`,
       }}>
         <strong style={designTokens.typography.title3}>Selected Call Debug</strong>
         <pre style={{


### PR DESCRIPTION
## Add TitleWrapper and Divider common component, and update Calls layout
This PR introduces two common UI components(TitleWrapper, Divider) and updates the Calls page layout to wrap the CallList with a titled header section.

## Key Changes
- Add TitleWrapper: renders a section title with optional divider and size variants(l, m, s)
- Add Divider: horizontal and vertical rule with spacing, color, and width
- Define shared types for TitleWrapper and Divider.
- Update Calls page with applying list pane layout styles
- Adjust CallItem icon sizes from 16px to 20px.

## Demo
https://github.com/user-attachments/assets/0d8366f9-7512-4279-a112-6ff30dce1c24

