### PR TITLE
Feat/create state component

### DIFF
--- a/src/components/calls/CallList.tsx
+++ b/src/components/calls/CallList.tsx
@@ -2,6 +2,7 @@ import { designTokens } from "../../design-tokens";
 import { CallItem } from "./CallItem";
 import type { CallList as ContactListProps, ContactItem } from "../types";
 import { useCallback } from "react";
+import { State } from '../common/State';
 
 export function CallList({
     calls,
@@ -9,6 +10,8 @@ export function CallList({
     onCallSelect,
     className,
     ariaLabel,
+    loading,
+    error
 }: ContactListProps & { contact?: ContactItem['contact'] }) {
 
     const listStyle: React.CSSProperties = {
@@ -20,6 +23,10 @@ export function CallList({
         gap: designTokens.spacing.xxxs,
         flex: '1 0 0',
     };
+
+    if (!calls.length) {
+        return <State variant="empty" title={`No calls found`} />;
+    }
 
     const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLUListElement>) => {
         if (!calls.length || !onCallSelect) return;
@@ -39,6 +46,19 @@ export function CallList({
         }
     }, [calls, selectedCallId, onCallSelect]);
 
+    const stateText =
+        error ? 'Something went wrong. Please try again later'
+            : loading ? 'Please wait...'
+                : !selectedCallId ? 'No call found' : '';
+
+    if (error) {
+        return <State variant="error" title={stateText} />;
+    } if (loading) {
+        return <State variant="loading" title={stateText} />;
+    } if (!calls.length) {
+        return <State variant="empty" title={stateText} />;
+    }
+
     return (
         <ul
             role="list"
@@ -48,21 +68,18 @@ export function CallList({
             tabIndex={0}
             onKeyDown={handleKeyDown}
         >
-            {calls.map(call => {
-
-                return (
-                    <CallItem
-                        callId={call.callId}
-                        callType={call.callType}
-                        callTime={call.callTime}
-                        phoneNumber={call.phoneNumber}
-                        contactName={call.contactName}
-                        duration={call.duration}
-                        selected={call.callId === selectedCallId}
-                        onClick={() => onCallSelect?.(call.callId)}
-                    />
-                );
-            })}
+            {calls.map(call => (
+                <CallItem
+                    callId={call.callId}
+                    callType={call.callType}
+                    callTime={call.callTime}
+                    phoneNumber={call.phoneNumber}
+                    contactName={call.contactName}
+                    duration={call.duration}
+                    selected={call.callId === selectedCallId}
+                    onClick={() => onCallSelect?.(call.callId)}
+                />
+            ))}
         </ul>
     );
 }

--- a/src/components/common/State.tsx
+++ b/src/components/common/State.tsx
@@ -1,0 +1,36 @@
+import type { State as StateProps } from '../types'
+import { Info, OctagonAlert, Coffee } from 'lucide-react';
+import { designTokens } from '../../design-tokens';
+
+export function State({
+    variant,
+    title,
+    className,
+}: StateProps) {
+
+    const wrapperStyle: React.CSSProperties = {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        padding: `${designTokens.spacing.xl} 0`,
+        gap: `${designTokens.spacing.s}`,
+    }
+
+    const icon =
+        variant === 'loading' ? <Coffee size={32} strokeWidth={1.5} color={designTokens.colors.glyph.default} />
+            : variant === 'error' ? <OctagonAlert size={32} strokeWidth={1.5} color={designTokens.colors.glyph.default} />
+                : <Info size={32} strokeWidth={1.5} color={designTokens.colors.glyph.default} />;
+
+
+    return (
+        <div
+            style={{ ...wrapperStyle }}
+            className={className}
+        >
+            <div>{icon}</div>
+            <div style={{ ...designTokens.typography.body }}>{title}</div>
+        </div>
+    )
+}

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -112,3 +112,10 @@ export type CallFilter = {
     className?: string;
     ariaLabel?: string;
 }
+
+export type State = {
+    variant: 'empty' | 'loading' | 'error';
+    title: string;
+    icon?: React.ReactNode;
+    className?: string;
+}

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -66,6 +66,8 @@ export type CallList = {
     onCallSelect?: (callId: string) => void;
     className?: string;
     ariaLabel?: string;
+    loading: boolean;
+    error?: string;
 }
 
 export type TitleWrapper = {

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -6,7 +6,7 @@ export const mockContacts = [
 
 export const mockCalls = [
     { id: "k1", contactId: "c1", phoneNumber: "+49 151 2345678", direction: "incoming" as const, startedAt: "2025-09-23T08:15:00Z", duration: 225 },
-    { id: "k2", contactId: "c2", phoneNumber: "+49 171 9876543", direction: "outgoing" as const, startedAt: "2025-09-22T13:45:00Z", duration: 78 },
+    // { id: "k2", contactId: "c2", phoneNumber: "+49 171 9876543", direction: "outgoing" as const, startedAt: "2025-09-22T13:45:00Z", duration: 78 },
     { id: "k3", contactId: "c3", phoneNumber: "+49 160 5550001", direction: "missed" as const, startedAt: "2025-09-24T06:05:00Z", duration: 234 },
     { id: "k4", contactId: "unknown", phoneNumber: "+49 160 5550001", direction: "missed" as const, startedAt: "2025-09-24T06:05:00Z", duration: 234 },
 ];

--- a/src/pages/Calls.tsx
+++ b/src/pages/Calls.tsx
@@ -4,15 +4,19 @@ import { CallFilter } from '../components/calls/CallFilter';
 import { useState } from 'react';
 import { designTokens } from '../design-tokens';
 import { TitleWrapper } from '../components/common/TitleWrapper';
+import { State } from '../components/common/State';
 import type { CallDirection } from '../components/types';
 
 
 export default function Calls() {
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
+  const [loading] = useState(false);
+  const [error] = useState<string | undefined>(undefined);
 
-  if (!mockCalls.length) {
-    return <div>No calls found</div>;
-  }
+  const stateText =
+    error ? 'Something went wrong. Please try again later'
+      : loading ? 'Please wait...'
+        : !selectedId ? 'No call history selected' : '';
 
   const callsWithContact = mockCalls.map(call => {
     const contact = mockContacts.find(c => c.id === call.contactId);
@@ -76,23 +80,32 @@ export default function Calls() {
           selectedCallId={selectedId}
           onCallSelect={setSelectedId}
           ariaLabel="Call History"
+          loading={loading}
+          error={error}
         />
       </div>
       <div style={{
         maxWidth: 400,
-        margin: '0 auto',
+        margin: 'auto',
         display: 'flex',
         flexDirection: 'column',
         flex: `1 0 0`,
         padding: `0 ${designTokens.spacing.l}`,
       }}>
-        <strong style={designTokens.typography.title3}>Selected Call Debug</strong>
-        <pre style={{
-          ...designTokens.typography.micro,
-          whiteSpace: 'pre-wrap',
-        }}>
-          {selectedCall ? JSON.stringify(selectedCall, null, 2) : 'No call selected'}
-        </pre>
+        {error ? (
+          <State variant="error" title={stateText} />
+        ) : loading ? (
+          <State variant="loading" title={stateText} />
+        ) : selectedCall ? (
+          <pre style={{
+            ...designTokens.typography.micro,
+            whiteSpace: 'pre-wrap',
+          }}>
+            {JSON.stringify(selectedCall, null, 2)}
+          </pre>
+        ) : (
+          <State variant="empty" title={stateText} />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Add State component and integrate loading/ error handling in Calls
This PR introduces a new common component named State, and integrates loading and error states into the Calls. This also aligns the CallList and Calls page with shared types. 

## Key Changes
- **CallList.tsx :** Handles empty, loading, and error states via State.
- **State.tsx :** New common component with variant of loading, error, empty
- **types.ts :** Adds State props; extends CallList with loading and optional error fields.
- **Call.tsx :** Wires loading/error to CallList (shows State for selected-call panel)

## Demo Video

https://github.com/user-attachments/assets/c534ed36-c157-428b-9fae-173ac48f9e78
